### PR TITLE
fix(browser): keep tab action receipts compact and site-scoped

### DIFF
--- a/plugins/browser/README.md
+++ b/plugins/browser/README.md
@@ -101,6 +101,12 @@ the upstream name-only WebMCP tools are excluded and rejected if called directly
 Both screenshot paths become normal Harness image attachments.
 Browser owns native tab creation/closure through `browser_open_tab` and
 `browser_close_tab`; `browser_select_tab` explicitly binds another same-site tab.
+Open/close receipts list compact state for this site's tabs; navigation receipts
+include only the bound tab. These action results omit tool schemas and global
+browser state. Call `browser_context` when tool discovery is needed. Navigation
+requests can return while loading is still in progress; the receipt is not a
+page-load assertion. A target that has left the site is marked `outside-site`
+without returning the other site's details.
 
 Each Agent uses an authenticated, loopback CDP bridge exposing only its bound
 website tab. It never exposes the Harness shell or a browser-wide debugging

--- a/plugins/browser/src/runtime.test.ts
+++ b/plugins/browser/src/runtime.test.ts
@@ -115,6 +115,7 @@ describe('BrowserRuntime', () => {
     call = async () => ({ articles: [{ title: 'Actual result' }] })
     request = vi.fn(async (command: BrowserNativeCommand) => {
       if (command.action === 'snapshot') return snapshot
+      if (command.action === 'tab.navigate' || command.action === 'tab.open' || command.action === 'tab.close') return snapshot
       if (command.action === 'webmcp.install') return install(command.script)
       if (command.action === 'webmcp.call') return call()
       if (command.action === 'page.screenshot') return { image: 'data:image/png;base64,AQID', documentId: command.documentId } satisfies import('./native-contract.js').BrowserScreenshot
@@ -132,6 +133,62 @@ describe('BrowserRuntime', () => {
     if (!tool) throw new Error(`Test tool missing: ${name}`)
     return JSON.parse(await tool.execute(args, { agent, signal: new AbortController().signal }))
   }
+
+  it.each([
+    ['browser_navigate', { url: '/next' }],
+    ['browser_open_tab', { url: '/next' }],
+    ['browser_close_tab', { tabId: 'tab-1' }],
+  ] as const)('%s keeps receipts on-site without tool schemas or global browser state', async (name, args) => {
+    snapshot.tabs.push({ ...snapshot.tabs[0]!, id: 'private-tab', origin: 'https://private.example', url: 'https://private.example/secret', title: 'Private tab' })
+    snapshot.activeTabId = 'private-tab'
+    snapshot.downloads = [{ id: 'download', filename: 'private.pdf', state: 'completed', receivedBytes: 1, totalBytes: 1 }]
+    snapshot.selections = [{ id: 'selection', tabId: 'private-tab', documentId: 'private-doc', text: 'Private selection', title: 'Private tab', url: 'https://private.example/secret' }]
+    snapshot.authentication = [{ id: 'auth', tabId: 'private-tab', host: 'private.example', realm: 'Private realm', isProxy: false }]
+    snapshot.tabs[0]!.tools = [{ ...GENERATED_TOOL, description: 'large schema '.repeat(1000) }]
+    await runtime.bind(site.id, agent.session.id, 'tab-1', 'use')
+
+    const result = await exec(name, args)
+    expect(result).toMatchObject({ open: true, tabs: [{ id: 'tab-1', documentId: 'document-1', loading: false }] })
+    const encoded = JSON.stringify(result)
+    for (const excluded of ['private', 'Private', 'downloads', 'selections', 'authentication', 'activeTabId', 'tools', 'large schema']) expect(encoded).not.toContain(excluded)
+    // The action projection must leave the desktop snapshot and explicit tool discovery intact.
+    expect((await runtime.state()).native).toEqual(snapshot)
+    expect(await exec('browser_context')).toMatchObject({ tabs: [{ tools: snapshot.tabs[0]!.tools }] })
+  })
+
+  it('returns only the navigated tab, retaining document, loading and error state', async () => {
+    snapshot.tabs.push({ ...snapshot.tabs[0]!, id: 'tab-2' })
+    await runtime.bind(site.id, agent.session.id, 'tab-1', 'use')
+    request.mockImplementation(async (command: BrowserNativeCommand) => {
+      if (command.action === 'tab.navigate') return { ...snapshot, tabs: [{ ...snapshot.tabs[0]!, url: `${ORIGIN}/next`, documentId: 'next-doc', loading: true, error: 'Navigation failed', webmcpError: 'Discovery failed' }, snapshot.tabs[1]!] }
+      return snapshot
+    })
+    expect(await exec('browser_navigate', { url: '/next' })).toEqual({
+      open: true, activeTabId: 'tab-1', target: { tabId: 'tab-1', status: 'present' },
+      tabs: [{ id: 'tab-1', url: `${ORIGIN}/next`, origin: ORIGIN, title: 'Articles', documentId: 'next-doc', loading: true, error: 'Navigation failed', webmcpError: 'Discovery failed' }],
+    })
+  })
+
+  it.each(['outside-site', 'closed'] as const)('reports a navigated target that is %s without exposing another site', async status => {
+    await runtime.bind(site.id, agent.session.id, 'tab-1', 'use')
+    request.mockImplementation(async (command: BrowserNativeCommand) => command.action === 'tab.navigate'
+      ? { ...snapshot, tabs: status === 'closed' ? [] : [{ ...snapshot.tabs[0]!, origin: 'https://private.example', url: 'https://private.example/secret', title: 'Private tab' }] }
+      : snapshot)
+    expect(await exec('browser_navigate', { url: '/next' })).toEqual({ open: true, tabs: [], target: { tabId: 'tab-1', status } })
+  })
+
+  it('rejects cross-site requests and propagates native navigation failures without retrying', async () => {
+    await runtime.bind(site.id, agent.session.id, 'tab-1', 'use')
+    await expect(exec('browser_navigate', { url: 'https://other.example/' })).rejects.toThrow('another site')
+    await expect(exec('browser_open_tab', { url: 'https://other.example/' })).rejects.toThrow('another site')
+    expect(request.mock.calls.some(([command]) => command.action.startsWith('tab.'))).toBe(false)
+    request.mockImplementation(async (command: BrowserNativeCommand) => {
+      if (command.action === 'tab.navigate') throw new Error('Native connection lost; result unknown')
+      return snapshot
+    })
+    await expect(exec('browser_navigate', { url: '/next' })).rejects.toThrow('result unknown')
+    expect(request.mock.calls.filter(([command]) => command.action === 'tab.navigate')).toHaveLength(1)
+  })
 
   it('binds only the site Workspace Session and a tab on the same origin', async () => {
     await expect(runtime.bind(site.id, 'missing-session', 'tab-1', 'use')).rejects.toThrow('Workspace')

--- a/plugins/browser/src/runtime.ts
+++ b/plugins/browser/src/runtime.ts
@@ -82,6 +82,23 @@ function sameBinding(left: BrowserBinding | undefined, right: BrowserBinding): b
   return left?.siteId === right.siteId && left.sessionId === right.sessionId && left.tabId === right.tabId && left.mode === right.mode
 }
 
+// Native snapshots also drive the desktop UI. Agent action receipts must not
+// copy global browser state or repeatedly include the WebMCP tool directory.
+function siteTabReceipt(snapshot: BrowserSnapshot, origin: string, targetTabId?: string): RecordValue {
+  const tabs = snapshot.tabs.filter(tab => tab.origin === origin && (!targetTabId || tab.id === targetTabId)).map(tab => ({
+    id: tab.id, url: tab.url, origin: tab.origin, title: tab.title,
+    documentId: tab.documentId, loading: tab.loading,
+    ...(tab.error !== undefined ? { error: tab.error } : {}),
+    ...(tab.webmcpError !== undefined ? { webmcpError: tab.webmcpError } : {}),
+  }))
+  const target = targetTabId ? snapshot.tabs.find(tab => tab.id === targetTabId) : undefined
+  return {
+    open: snapshot.open, tabs,
+    ...(tabs.some(tab => tab.id === snapshot.activeTabId) ? { activeTabId: snapshot.activeTabId } : {}),
+    ...(targetTabId ? { target: { tabId: targetTabId, status: !target ? 'closed' : target.origin === origin ? 'present' : 'outside-site' } } : {}),
+  }
+}
+
 export function verifiedInstallation(value: unknown, origin: string, revision: string): RecordValue {
   const receipt = argsObject(value)
   if (receipt.installed !== true || receipt.origin !== origin || receipt.revision !== revision || receipt.failed !== 0
@@ -353,11 +370,11 @@ export class BrowserRuntime {
       this.tool(state, 'browser_open_tab', 'Open another native Browser tab within this site. Select it explicitly with browser_select_tab to move this Agent to it.', { url: string }, ['url'], async (args, exec, site) => {
         const url = new URL(requiredString(args, 'url'), site.origin).href
         if (siteOrigin(url) !== site.origin) throw new Error('Navigation belongs to another site.')
-        return this.native.request({ action: 'tab.open', url }, exec.signal)
+        return siteTabReceipt(await this.native.request({ action: 'tab.open', url }, exec.signal), site.origin)
       }),
       this.tool(state, 'browser_close_tab', 'Close an explicitly selected tab of this site. Closing the bound tab requires selecting another before continuing.', { tabId: string }, ['tabId'], async (args, exec, site) => {
         const tab = await this.tab(requiredString(args, 'tabId'), site.origin)
-        return this.native.request({ action: 'tab.close', tabId: tab.id }, exec.signal)
+        return siteTabReceipt(await this.native.request({ action: 'tab.close', tabId: tab.id }, exec.signal), site.origin)
       }),
       this.tool(state, 'browser_context', 'Discover this site, the bound tab, live native and generated WebMCP tools and Builder source context.', {}, [], async (_args, _exec, site) => ({ site: await this.describe(site), binding: state.binding, tabs: (await this.snapshot()).tabs.filter(tab => tab.origin === site.origin), webmcp: await this.webmcp.inspect(site.origin) })),
       this.tool(state, 'browser_set_mode', 'Switch this same site conversation between use and WebMCP Builder modes. After building, return to use and finish the original task.', { mode: { type: 'string', enum: ['use', 'builder'] } }, ['mode'], async args => {
@@ -381,11 +398,11 @@ export class BrowserRuntime {
         state.binding = binding
         return state.binding
       }),
-      this.tool(state, 'browser_navigate', 'Navigate the bound tab within this site, then rediscover tools. Cross-site work requires that site’s own Agent.', { url: string }, ['url'], async (args, exec, site) => {
+      this.tool(state, 'browser_navigate', 'Navigate the bound tab within this site. Returns compact tab state; call browser_context to rediscover tools. Cross-site work requires that site’s own Agent.', { url: string }, ['url'], async (args, exec, site) => {
         const url = new URL(requiredString(args, 'url'), site.origin).href
         if (siteOrigin(url) !== site.origin) throw new Error('Navigation belongs to another site.')
         await this.target(state, site)
-        return this.native.request({ action: 'tab.navigate', tabId: state.binding.tabId, url }, exec.signal)
+        return siteTabReceipt(await this.native.request({ action: 'tab.navigate', tabId: state.binding.tabId, url }, exec.signal), site.origin, state.binding.tabId)
       }),
       this.tool(state, 'browser_webmcp_call', 'Execute a discovered WebMCP tool and wait for its actual result. Copy frameId/documentId/revision from browser_context; never invent a tool.', { name: string, frameId: string, documentId: string, input: object, revision: string }, ['name', 'frameId', 'documentId', 'input'], async (args, exec, site) => {
         const target = await this.target(state, site)


### PR DESCRIPTION
Browser tab actions returned the full native browser snapshot to a site Agent, including unrelated tabs, repeated WebMCP schemas, and global download/selection/authentication state. Navigation now returns compact metadata for the bound tab; open/close return compact metadata for same-origin tabs. Explicit `browser_context` discovery still returns the site's tool directory.

The Cordis plugin projects the native response without changing the desktop snapshot. Document IDs, loading state and errors remain visible. A navigated target that has left the origin is marked `outside-site` without exposing that site's details. Navigation still requests a load asynchronously; its receipt does not assert that the page finished loading. Native failures propagate without retries.

Validation: `pnpm check`, `pnpm test`, and `pnpm build` passed locally. Seven added regression cases cover all three action receipts, site isolation, large tool descriptions, redirect/closed targets, preserved metadata/discovery/UI state, and failure propagation. No Harness or Electron host changes.

This reduces action-result payloads; it is not an end-to-end token or latency benchmark.
