### PR TITLE
Add NGA Forums WebMCP to registry

### DIFF
--- a/apps/web/public/webmcp/catalog.json
+++ b/apps/web/public/webmcp/catalog.json
@@ -1,5 +1,31 @@
 {
   "formatVersion": 1,
-  "generatedAt": "2026-09-10T07:42:47.177Z",
-  "entries": []
+  "generatedAt": "2026-09-11T05:39:20.043Z",
+  "entries": [
+    {
+      "id": "nga-forums-webmcp",
+      "repositoryId": 1365304362,
+      "repository": "https://github.com/jo32/nga-forums-webmcp",
+      "manifestPath": "webmcp.json",
+      "name": "NGA Forums WebMCP",
+      "description": "Browse NGA forum directories, featured topics, board topic lists and topic pages, and inspect or operate the native NGA login flow without exposing credentials.",
+      "origin": "https://bbs.nga.cn",
+      "tags": [
+        "nga",
+        "forum",
+        "community",
+        "topics",
+        "discussion",
+        "login"
+      ],
+      "status": "active",
+      "author": {
+        "login": "jo32",
+        "url": "https://github.com/jo32",
+        "avatarUrl": "https://github.com/jo32.png?size=80"
+      },
+      "syncedAt": "2026-09-11T05:39:20.041Z",
+      "commit": "8ea7f0aab887a636804650bcb0def4345cffcadd"
+    }
+  ]
 }

--- a/plugins/browser/catalog.json
+++ b/plugins/browser/catalog.json
@@ -1,5 +1,31 @@
 {
   "formatVersion": 1,
-  "generatedAt": "2026-09-10T07:42:47.177Z",
-  "entries": []
+  "generatedAt": "2026-09-11T05:39:20.043Z",
+  "entries": [
+    {
+      "id": "nga-forums-webmcp",
+      "repositoryId": 1365304362,
+      "repository": "https://github.com/jo32/nga-forums-webmcp",
+      "manifestPath": "webmcp.json",
+      "name": "NGA Forums WebMCP",
+      "description": "Browse NGA forum directories, featured topics, board topic lists and topic pages, and inspect or operate the native NGA login flow without exposing credentials.",
+      "origin": "https://bbs.nga.cn",
+      "tags": [
+        "nga",
+        "forum",
+        "community",
+        "topics",
+        "discussion",
+        "login"
+      ],
+      "status": "active",
+      "author": {
+        "login": "jo32",
+        "url": "https://github.com/jo32",
+        "avatarUrl": "https://github.com/jo32.png?size=80"
+      },
+      "syncedAt": "2026-09-11T05:39:20.041Z",
+      "commit": "8ea7f0aab887a636804650bcb0def4345cffcadd"
+    }
+  ]
 }

--- a/registry/webmcp/entries/nga-forums-webmcp.json
+++ b/registry/webmcp/entries/nga-forums-webmcp.json
@@ -1,0 +1,6 @@
+{
+  "id": "nga-forums-webmcp",
+  "repositoryId": 1365304362,
+  "repository": "https://github.com/jo32/nga-forums-webmcp",
+  "manifestPath": "webmcp.json"
+}


### PR DESCRIPTION
Adds NGA Forums WebMCP to the DeepDeck directory for https://bbs.nga.cn. The registry reference uses GitHub repository ID `1365304362`, and both catalog snapshots point to verified source commit `8ea7f0aab887a636804650bcb0def4345cffcadd`.

The project has an MIT license and no stable release, so it is listed as a development preview with installation pinned to the full commit SHA.

Validation: registry synchronization and `--check` verify repository identity, manifest/source integrity, and snapshot consistency. `pnpm check`, `pnpm test`, and `pnpm build` passed.
