### PR TITLE
Publish registry API and directory automatically on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,5 @@ jobs:
 
       - name: Build DeepDeck
         run: pnpm build
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/webmcp-registry.yml
+++ b/.github/workflows/webmcp-registry.yml
@@ -9,6 +9,8 @@ on:
       - 'plugins/browser/src/webmcp-package.ts'
       - 'plugins/browser/catalog.json'
       - 'apps/web/public/webmcp/catalog.json'
+      - 'apps/web/app/api/webmcp/**'
+      - 'apps/web/package.json'
       - '.github/workflows/webmcp-registry.yml'
   push:
     branches: [main]
@@ -32,7 +34,7 @@ jobs:
           package-manager-cache: false
       - name: Test registry validation
         run: npx --yes --package=tsx@4.22.4 tsx --test scripts/sync-webmcp-registry.test.mjs
-      - name: Validate references and committed catalog snapshots
-        run: npx --yes --package=tsx@4.22.4 tsx scripts/sync-webmcp-registry.ts --check
+      - name: Validate registry references against GitHub
+        run: npx --yes --package=tsx@4.22.4 tsx scripts/sync-webmcp-registry.ts --validate
         env:
           GH_TOKEN: ${{ github.token }}

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,10 +4,11 @@
 
 `/webmcp` and `/zh/webmcp` provide searchable GitHub project references, upstream
 issues/releases and installation instructions for the Browser Community panel.
-The checked-in `public/webmcp/catalog.json` starts empty. Add references under
-`registry/webmcp/entries` and run `pnpm webmcp:sync` at the repository root to refresh
-the snapshot; deploy the website to publish it. No GitHub credentials reach the
-page, and builds do not call GitHub. See `registry/webmcp/README.md` for contributions.
+Add references under `registry/webmcp/entries`. Each website build synchronizes
+and validates these references against GitHub before generating the pages and
+`/api/webmcp/catalog`. Clients read this public mirror without connecting to
+GitHub. `/webmcp/catalog.json` serves the same data for older clients. No GitHub
+credentials reach the page or API. See `registry/webmcp/README.md` for contributions.
 
 DeepDeck 的官方介绍站，使用 Next.js App Router 与 Geist 构建。
 
@@ -58,4 +59,8 @@ The directory UI now lives in `plugins/browser/src/client/WebMCPDirectory.tsx`, 
 
 ## Publish the registry website
 
-Build from the complete monorepo so the shared Browser directory component is available. For the existing `deepdeck` Vercel project, link the repository root to that project with its Vercel Root Directory set to `apps/web`, then run `vercel pull --yes --environment=production`, `vercel build --prod`, and `vercel deploy --prebuilt --prod` from the repository root. The Vercel configuration uses the pinned pnpm workspace install; Turbopack and output tracing include the monorepo root. Verify `/webmcp`, `/zh/webmcp`, and `/webmcp/catalog.json` after deployment. Never create a replacement Vercel project or change DNS for a registry update.
+The existing `deepdeck` Vercel project is connected to `jo32/DeepDeck`, with production branch `main`, Root Directory `apps/web`, and files outside the root included. A merge automatically builds and publishes the website. `ignoreCommand: "exit 1"` prevents registry-only changes outside `apps/web` from being skipped. No separate desktop deployment is involved.
+
+`pnpm web:build` first runs `registry:sync`, using the workspace's pinned `tsx` dependency (no Harness build is required). It fetches GitHub metadata/source and fails publication if validation fails, keeping the previous deployment live. An optional server-only `GH_TOKEN` build environment variable raises GitHub API limits. Local development uses the checked-in snapshot until you run synchronization.
+
+For manual recovery, link the repository root to that same Vercel project, then run `vercel pull --yes --environment=production`, `vercel build --prod`, and `vercel deploy --prebuilt --prod` from the repository root. Verify `/api/webmcp/catalog`, `/webmcp/catalog.json`, `/webmcp`, and `/zh/webmcp` after deployment. Never create a replacement Vercel project or change DNS for a registry update.

--- a/apps/web/app/api/webmcp/catalog/route.ts
+++ b/apps/web/app/api/webmcp/catalog/route.ts
@@ -1,0 +1,16 @@
+import snapshot from '../../../../public/webmcp/catalog.json'
+import { parseCatalog } from '../../../../../../plugins/browser/src/webmcp-package.ts'
+
+// GitHub is read and verified during the build, never on a client's request.
+// The API and directory pages publish together as one immutable deployment.
+export const dynamic = 'force-static'
+
+export function GET() {
+  return Response.json(parseCatalog(snapshot), {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'public, max-age=60, s-maxage=300',
+      ...(process.env.VERCEL_GIT_COMMIT_SHA ? { 'X-WebMCP-Registry-Commit': process.env.VERCEL_GIT_COMMIT_SHA } : {}),
+    },
+  })
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,16 @@ const nextConfig: NextConfig = {
   turbopack: { root: resolve(import.meta.dirname, "../..") },
   outputFileTracingRoot: resolve(import.meta.dirname, "../.."),
   reactStrictMode: true,
+  async headers() {
+    return [{
+      // Older desktop clients use this URL and must receive the same fresh mirror.
+      source: "/webmcp/catalog.json",
+      headers: [
+        { key: "Access-Control-Allow-Origin", value: "*" },
+        { key: "Cache-Control", value: "public, max-age=60, s-maxage=300" },
+      ],
+    }];
+  },
   async redirects() {
     return [
       {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "pnpm registry:sync && next build",
+    "registry:sync": "tsx ../../scripts/sync-webmcp-registry.ts --website-only",
     "start": "next start",
     "check": "tsc --noEmit"
   },
@@ -18,6 +19,7 @@
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
-    "typescript": "^5.9.0"
+    "typescript": "^5.9.0",
+    "tsx": "4.22.4"
   }
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "installCommand": "pnpm install --frozen-lockfile"
+  "installCommand": "pnpm install --frozen-lockfile",
+  "ignoreCommand": "exit 1"
 }

--- a/plugins/browser/src/webmcp-package.ts
+++ b/plugins/browser/src/webmcp-package.ts
@@ -1,6 +1,6 @@
 /** Shared, browser-safe GitHub package and directory contract. */
 export const WEBMCP_MARKET_URL = 'https://deepdeck.getmegaportal.com/webmcp'
-export const WEBMCP_CATALOG_URL = 'https://deepdeck.getmegaportal.com/webmcp/catalog.json'
+export const WEBMCP_CATALOG_URL = 'https://deepdeck.getmegaportal.com/api/webmcp/catalog'
 export const WEBMCP_REGISTRY_URL = 'https://github.com/jo32/DeepDeck/tree/main/registry/webmcp'
 export interface WebMCPPackage {
   formatVersion: 1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.0
         version: 19.2.4(@types/react@19.2.18)
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.9.0
         version: 5.9.3
@@ -4431,6 +4434,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
@@ -9116,6 +9124,12 @@ snapshots:
   ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-fest@0.13.1:
     optional: true

--- a/registry/webmcp/README.md
+++ b/registry/webmcp/README.md
@@ -1,6 +1,6 @@
 # WebMCP directory
 
-This directory stores references to public GitHub projects. Source, issues, pull requests and releases remain in each project's repository. The initial catalog is intentionally empty.
+This directory is the source of truth for the official WebMCP directory. It stores references to public GitHub projects. Source, issues, pull requests and releases remain in each project's repository.
 
 To list a project, add `entries/<short-name>.json` in a pull request to this repository:
 
@@ -17,20 +17,26 @@ Use the actual numeric GitHub repository ID, not the illustrative value above. I
 
 Projects without a stable release can be listed for discovery; installation of unreleased source requires an explicit full commit SHA. GitHub stars, a recent commit, and successful registration are not functional verification. Issues and repairs link to upstream.
 
-Run `pnpm webmcp:sync` to validate references, retrieve GitHub metadata and atomically regenerate `apps/web/public/webmcp/catalog.json`. `GH_TOKEN` is optional for authenticated API limits and is used only by the sync process. Missing references are removed, failed syncs preserve an existing entry with a warning, and duplicate references or malformed inputs fail the command. The website build does not require live GitHub access.
+Merging a registry change to `main` automatically triggers the existing `deepdeck` Vercel project's Git integration. Its website build reads the checked-out `entries/`, retrieves GitHub metadata, verifies repository identity, manifest, license and source hashes, and generates the directory. The website and API publish in the same deployment. Contributors only need to commit reference changes; generated snapshots are not required in listing PRs.
 
-Review reference changes and the generated catalog together. A listing PR does not grant the submitter ownership of the project. If a repository changes ID or becomes archived/unavailable, review its listing instead of silently replacing its source. Renames currently require updating the canonical URL in the reference.
+GitHub requests happen in the build environment, not on client devices. Clients fetch the public mirror at `https://deepdeck.getmegaportal.com/api/webmcp/catalog`. The previous `/webmcp/catalog.json` URL remains available with the same data for installed clients. Both endpoints allow cross-origin reads and cache for at most five minutes at the CDN. No desktop release or manual website deployment is needed for registry updates.
 
-The site reads the checked-in snapshot. Refresh it with this command and deploy the website to update the public directory. The WebMCP registry workflow validates reference changes and snapshot consistency on pull requests and pushes. It does not publish packages, merge submissions or deploy the website. No background schedule or GitHub webhook is configured automatically.
+`GH_TOKEN` is optional for authenticated API limits and is used only by synchronization. For larger registries, configure a read-only GitHub token as a Vercel build environment variable. Never expose it through a `NEXT_PUBLIC_` variable. If GitHub is unavailable, a reference is invalid, or integrity verification fails, the build fails and the previous production deployment remains live.
+
+Review reference changes and their upstream projects together. A listing PR does not grant the submitter ownership of the project. If a repository changes ID or becomes archived/unavailable, review its listing instead of silently replacing its source. Renames currently require updating the canonical URL in the reference.
+
+The registry workflow validates references on pull requests and pushes using GitHub's read-only workflow token. Vercel's Git integration handles previews and production publication separately. The project must include files outside `apps/web` and must not skip builds when only `registry/` changes (`apps/web/vercel.json` sets `ignoreCommand` accordingly). This workflow publishes the website only; it does not publish desktop packages or upstream WebMCP releases.
 
 ## Validation and publication
 
-The live catalog is [catalog.json](https://deepdeck.getmegaportal.com/webmcp/catalog.json); browse it at [the directory](https://deepdeck.getmegaportal.com/webmcp).
+The live catalog is [the registry API](https://deepdeck.getmegaportal.com/api/webmcp/catalog); browse it at [the directory](https://deepdeck.getmegaportal.com/webmcp).
 
 1. Add or update a reference under `entries/`, following [entry.schema.json](entry.schema.json).
-2. Run `pnpm webmcp:sync` using an existing GitHub login token in `GH_TOKEN` when needed. Never commit credentials.
-3. Include both generated snapshots: `apps/web/public/webmcp/catalog.json` and `plugins/browser/catalog.json`.
-4. Run `pnpm webmcp:sync --check` to validate without changing files. CI checks repository identity, manifest/source integrity, licenses, duplicates and the committed snapshots.
-5. Open a PR. After review and merge, deploy the website to update discovery. Desktop installations use the live JSON and may fall back to the bundled snapshot.
+2. Run `pnpm webmcp:sync --validate` to check the references without changing files. Use an existing GitHub login token in `GH_TOKEN` when needed. Never commit credentials.
+3. Open a PR containing the reference changes. Wait for registry validation and review.
+4. Merge to `main`. Vercel automatically runs the website build, including `pnpm --filter @deepdeck/web registry:sync`, and publishes the updated site and API.
+5. Verify the live API and directory. Desktop installations fetch the new catalog on refresh and may fall back to their bundled snapshot when offline.
+
+For local inspection, `pnpm webmcp:sync` still refreshes both checked-in snapshots, and `--check` verifies their consistency. Desktop maintainers can include refreshed snapshots in an app release to update its offline fallback. `--website-only` regenerates only the website snapshot and aborts without replacing output on any upstream failure; this is the website build's mode.
 
 Local synchronization and an open PR do not mean a project is indexed on the public website. Verify the live JSON after deployment.

--- a/scripts/sync-webmcp-registry.test.mjs
+++ b/scripts/sync-webmcp-registry.test.mjs
@@ -5,9 +5,20 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { GET } from '../apps/web/app/api/webmcp/catalog/route.ts';
+import { parseCatalog, WEBMCP_CATALOG_URL } from '../plugins/browser/src/webmcp-package.ts';
 
 const source = fileURLToPath(new URL('../', import.meta.url));
 const empty = { formatVersion: 1, generatedAt: null, entries: [] };
+test('official API mirrors the legacy catalog and permits cross-origin client reads', async () => {
+  const response = GET();
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('access-control-allow-origin'), '*');
+  assert.match(response.headers.get('cache-control'), /s-maxage=300/);
+  const legacy = JSON.parse(await readFile(join(source, 'apps/web/public/webmcp/catalog.json'), 'utf8'));
+  assert.deepEqual(await response.json(), parseCatalog(legacy));
+  assert.equal(WEBMCP_CATALOG_URL, 'https://deepdeck.getmegaportal.com/api/webmcp/catalog');
+});
 async function fixture(run) {
   const root = await mkdtemp(join(tmpdir(), 'registry-check-'));
   try {
@@ -18,8 +29,19 @@ async function fixture(run) {
     const bundled = join(root, 'plugins/browser/catalog.json');
     const bytes = JSON.stringify(empty);
     await writeFile(catalog, bytes); await writeFile(bundled, bytes);
-    const invoke = () => spawnSync(process.execPath, [...process.execArgv.filter(arg => arg !== '--test'), join(root, 'scripts/sync-webmcp-registry.ts'), '--check'], { encoding: 'utf8' });
-    await run({ root, catalog, bundled, bytes, invoke });
+    const invoke = (mode = '--check') => spawnSync(process.execPath, [...process.execArgv.filter(arg => arg !== '--test'), join(root, 'scripts/sync-webmcp-registry.ts'), mode], { encoding: 'utf8' });
+    const addProject = async (fail = false) => {
+      const ref = { id: 'test-project', repositoryId: 1, repository: 'https://github.com/test/project', manifestPath: 'webmcp.json' };
+      await writeFile(join(root, 'registry/webmcp/entries/test.json'), JSON.stringify(ref));
+      // Stub only the GitHub transport boundary; exercise the real CLI and filesystem.
+      await writeFile(join(root, 'plugins/browser/src/github-webmcp.ts'), `
+        export class GitHubWebMCP {
+          async repository() { ${fail ? "throw new Error('Upstream unavailable')" : `return ${JSON.stringify({ ...ref, archived: false })}`} }
+          async load() { return ${JSON.stringify({ manifest: { name: 'Test project', description: 'An upstream project', origin: 'https://example.com', tags: [], license: 'MIT' }, provenance: { commit: 'a'.repeat(40) } })} }
+        }
+      `);
+    };
+    await run({ root, catalog, bundled, bytes, invoke, addProject });
   } finally { await rm(root, { recursive: true, force: true }); }
 }
 test('empty registry validates without rewriting either snapshot', () => fixture(async ({ catalog, bundled, bytes, invoke }) => {
@@ -39,4 +61,33 @@ test('divergent desktop snapshot fails without overwriting it', () => fixture(as
   await writeFile(bundled, bytes);
   const result = invoke(); assert.notEqual(result.status, 0); assert.match(result.stderr, /snapshots differ/);
   assert.equal(await readFile(bundled, 'utf8'), bytes);
+}));
+test('reference-only PR validates even when both snapshots are old', () => fixture(async ({ catalog, bundled, bytes, invoke, addProject }) => {
+  await addProject();
+  const result = invoke('--validate'); assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Validated 1/);
+  assert.equal(await readFile(catalog, 'utf8'), bytes); assert.equal(await readFile(bundled, 'utf8'), bytes);
+}));
+test('website build publishes additions and removals without rewriting the desktop fallback', () => fixture(async ({ root, catalog, bundled, bytes, invoke, addProject }) => {
+  await addProject();
+  const added = invoke('--website-only'); assert.equal(added.status, 0, added.stderr);
+  const result = JSON.parse(await readFile(catalog, 'utf8'));
+  assert.equal(result.entries[0].id, 'test-project');
+  assert.equal(result.entries[0].commit, 'a'.repeat(40));
+  assert.equal(await readFile(bundled, 'utf8'), bytes);
+  await rm(join(root, 'registry/webmcp/entries/test.json'));
+  const removed = invoke('--website-only'); assert.equal(removed.status, 0, removed.stderr);
+  assert.deepEqual(JSON.parse(await readFile(catalog, 'utf8')).entries, []);
+  assert.equal(await readFile(bundled, 'utf8'), bytes);
+}));
+test('failed upstream validation aborts publication and preserves the previous output', () => fixture(async ({ catalog, bundled, bytes, invoke, addProject }) => {
+  await addProject();
+  assert.equal(invoke('--website-only').status, 0);
+  const previous = await readFile(catalog, 'utf8');
+  await addProject(true);
+  const result = invoke('--website-only'); assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /publication aborted/);
+  assert.equal(await readFile(catalog, 'utf8'), previous);
+  assert.equal(await readFile(bundled, 'utf8'), bytes);
+  assert.notEqual(invoke('--validate').status, 0);
 }));

--- a/scripts/sync-webmcp-registry.ts
+++ b/scripts/sync-webmcp-registry.ts
@@ -5,6 +5,9 @@ import { GitHubWebMCP } from '../plugins/browser/src/github-webmcp.ts'
 import { packagePath, parseCatalog, record, repositoryUrl, type WebMCPCatalogEntry } from '../plugins/browser/src/webmcp-package.ts'
 
 const check = process.argv.includes('--check')
+const validate = process.argv.includes('--validate')
+const websiteOnly = process.argv.includes('--website-only')
+if ([check, validate, websiteOnly].filter(Boolean).length > 1) throw new Error('Choose only one synchronization mode.')
 const root = fileURLToPath(new URL('../', import.meta.url))
 const destination = join(root, 'apps/web/public/webmcp/catalog.json')
 const previous = parseCatalog(JSON.parse(await readFile(destination, 'utf8')))
@@ -37,6 +40,8 @@ for (const ref of references) {
   }
 }
 const catalog = parseCatalog({ formatVersion: 1, generatedAt: new Date().toISOString(), entries })
+// A production build must never replace the last working directory with partial results.
+if (websiteOnly && failed) throw new Error('Registry synchronization failed; website publication aborted.')
 if (check) {
   const normalize = (catalog: typeof previous) => JSON.stringify(catalog.entries.map(({ syncedAt, ...entry }) => entry).sort((a, b) => a.id.localeCompare(b.id)))
   if (normalize(previous) !== normalize(catalog)) {
@@ -48,15 +53,17 @@ if (check) {
     console.error('Website and bundled catalog snapshots differ.')
     failed = true
   }
-} else {
+} else if (!validate) {
   await mkdir(join(root, 'apps/web/public/webmcp'), { recursive: true })
   const temporary = `${destination}.${process.pid}.tmp`
   await writeFile(temporary, JSON.stringify(catalog, null, 2) + '\n')
   await rename(temporary, destination)
-  const bundledDestination = join(root, 'plugins/browser/catalog.json')
-  const bundledTemporary = `${bundledDestination}.${process.pid}.tmp`
-  await writeFile(bundledTemporary, JSON.stringify(catalog, null, 2) + '\n')
-  await rename(bundledTemporary, bundledDestination)
+  if (!websiteOnly) {
+    const bundledDestination = join(root, 'plugins/browser/catalog.json')
+    const bundledTemporary = `${bundledDestination}.${process.pid}.tmp`
+    await writeFile(bundledTemporary, JSON.stringify(catalog, null, 2) + '\n')
+    await rename(bundledTemporary, bundledDestination)
+  }
 }
-console.log(`${check ? 'Validated' : 'Indexed'} ${entries.length} WebMCP projects.`)
+console.log(`${check || validate ? 'Validated' : 'Indexed'} ${entries.length} WebMCP projects.`)
 if (failed) process.exitCode = 1


### PR DESCRIPTION
Registry changes currently require manually regenerating catalogs and deploying the website. This change lets contributors submit registry references and makes the website build validate and regenerate the directory before publication.

- Serve the validated build snapshot at `/api/webmcp/catalog`, with CORS and bounded caching; keep `/webmcp/catalog.json` available for installed clients.
- Point the shared client catalog URL to the official API. GitHub reads happen during the website build, so catalog discovery does not require client access to GitHub.
- Allow reference-only listing PRs with `--validate`. Website builds use `--website-only`, preserve the desktop fallback, and abort publication on upstream errors.
- Connect the existing DeepDeck Vercel project to this repository's `main` branch and prevent registry-only changes outside `apps/web` from being skipped.

Validation: `pnpm check`, `pnpm test`, and `pnpm build` passed. Regression tests cover API/legacy compatibility, reference-only submissions, additions/removals, and preserving output on upstream failure. Automatic Vercel preview and production deployment will be verified through this PR.
