### PR TITLE
registry: add X WebMCP

### DIFF
--- a/registry/webmcp/entries/x-webmcp.json
+++ b/registry/webmcp/entries/x-webmcp.json
@@ -1,0 +1,6 @@
+{
+  "id": "x-webmcp",
+  "repositoryId": 1365569333,
+  "repository": "https://github.com/jo32/x-webmcp",
+  "manifestPath": "webmcp.json"
+}


### PR DESCRIPTION
## Add X WebMCP repository reference

- Repository: https://github.com/jo32/x-webmcp
- GitHub repository ID: 1365569333
- Manifest: `webmcp.json`
- Reviewed source commit: `262f47fc3c625936762fdb713faba1e6e6c95987`
- Source SHA-256: `e14f9d5b6fe43ae7f74da2e4655ce2ce3b739a61f782ec1db3129c3bbbf30e10`
- Exact origin: https://x.com
- License: MIT

Only a repository reference is added; no source, generated snapshots or compiled bundles. Checked existing registry entries and open PRs before submission; no duplicate X reference was found.

The project is unreleased. No stable tag or release is requested; installation requires an explicit full commit SHA, per the registry guide's unreleased-project policy.

## Verification

The exact source was compiled with DeepDeck's esbuild@0.25.12 pipeline and registered 18 tools. Functionally checked signed-in detection, search query/results transition, plain multiline Unicode draft replacement, stale-value rejection and restoration of the empty draft. Nothing was published or reacted to during tests. Detailed digest-scoped evidence and limitations are in the repository's VERIFICATION.md. Companion skill inventory is empty.

Login submission, publishing, reactions, rich entities and advanced editors remain unverified or unsupported. Successful registration is not claimed as complete functional coverage.

Registry reference schema fields and public repository identity were checked. The registry CI should perform full validation; local `pnpm webmcp:sync --validate` was not run because this contribution uses the GitHub API rather than a full DeepDeck checkout. This PR is a submission, not a merged or indexed listing.
